### PR TITLE
Using several identical downstreams with different authentication schemes

### DIFF
--- a/SampleOcelot/Startup.cs
+++ b/SampleOcelot/Startup.cs
@@ -22,7 +22,13 @@ namespace SampleOcelot
         {
             services
                 .AddAuthentication()
-                .AddJwtBearer(options =>
+                .AddJwtBearer("Bearer", options =>
+                {
+                    options.Authority = Configuration["AUTHENTICATION_AUTHORITY"];
+                    options.Audience = "api1";
+                    options.RequireHttpsMetadata = false;
+                })
+                .AddJwtBearer("SomeOtherScheme", options =>
                 {
                     options.Authority = Configuration["AUTHENTICATION_AUTHORITY"];
                     options.Audience = "api1";

--- a/SampleOcelot/ocelot-local/ocelot-local.weather.json
+++ b/SampleOcelot/ocelot-local/ocelot-local.weather.json
@@ -23,6 +23,54 @@
         "AuthenticationProviderKey": "Bearer",
         "AllowedScopes": []
       }
+    },
+    {
+      "SwaggerKey": "weather",
+      "DownstreamPathTemplate": "/api/v2/weatherforecast",
+      "UpstreamPathTemplate": "/api/v2/forecastCustomAuth",
+      "UpstreamHttpMethod": [
+        "Post"
+      ],
+      "AddHeadersToRequest": {
+      },
+      "AddQueriesToRequest": {
+        "city": "Claims[location] > value"
+      },
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "weather-service",
+          "Port": 8080
+        }
+      ],
+      "AuthenticationOptions": {
+        "AuthenticationProviderKey": "Bearer",
+        "AllowedScopes": []
+      }
+    },
+    {
+      "SwaggerKey": "weather",
+      "DownstreamPathTemplate": "/api/v2/weatherforecast",
+      "UpstreamPathTemplate": "/api/v2/forecastDefaultAuth",
+      "UpstreamHttpMethod": [
+        "Post"
+      ],
+      "AddHeadersToRequest": {
+      },
+      "AddQueriesToRequest": {
+        "city": "Claims[location] > value"
+      },
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "weather-service",
+          "Port": 8080
+        }
+      ],
+      "AuthenticationOptions": {
+        "AuthenticationProviderKey": "SomeOtherScheme",
+        "AllowedScopes": []
+      }
     }
   ],
   "SwaggerSettings": {

--- a/SampleOcelot/ocelot/ocelot.weather.json
+++ b/SampleOcelot/ocelot/ocelot.weather.json
@@ -23,6 +23,54 @@
         "AuthenticationProviderKey": "Bearer",
         "AllowedScopes": []
       }
+    },
+    {
+      "SwaggerKey": "weather",
+      "DownstreamPathTemplate": "/api/v2/weatherforecast",
+      "UpstreamPathTemplate": "/api/v2/forecastCustomAuth",
+      "UpstreamHttpMethod": [
+        "Post"
+      ],
+      "AddHeadersToRequest": {
+      },
+      "AddQueriesToRequest": {
+        "city": "Claims[location] > value"
+      },
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "weather-service",
+          "Port": 8080
+        }
+      ],
+      "AuthenticationOptions": {
+        "AuthenticationProviderKey": "Bearer",
+        "AllowedScopes": []
+      }
+    },
+    {
+      "SwaggerKey": "weather",
+      "DownstreamPathTemplate": "/api/v2/weatherforecast",
+      "UpstreamPathTemplate": "/api/v2/forecastDefaultAuth",
+      "UpstreamHttpMethod": [
+        "Post"
+      ],
+      "AddHeadersToRequest": {
+      },
+      "AddQueriesToRequest": {
+        "city": "Claims[location] > value"
+      },
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "weather-service",
+          "Port": 8080
+        }
+      ],
+      "AuthenticationOptions": {
+        "AuthenticationProviderKey": "SomeOtherScheme",
+        "AllowedScopes": []
+      }
     }
   ],
   "SwaggerSettings": {

--- a/Swaggelot/SwaggerTransformer.cs
+++ b/Swaggelot/SwaggerTransformer.cs
@@ -220,7 +220,7 @@ namespace Swaggelot
                     operation.Value.Security = new List<OpenApiSecurityRequirement>();
                     operation.Value.Security.Add(req);
 
-                    operation.Value.Responses.Add("401", new OpenApiResponse()
+                    operation.Value.Responses.TryAdd("401", new OpenApiResponse()
                     {
                         Description = "Unauthorized"
                     });

--- a/WeatherService/Controllers/WeatherForecastController.cs
+++ b/WeatherService/Controllers/WeatherForecastController.cs
@@ -12,7 +12,7 @@ namespace WeatherService.Controllers
     [Route("api/v{version:apiVersion}/weatherforecast")]
     public class WeatherForecastController : ControllerBase
     {
-        private static readonly string[] Summaries = {
+        private static readonly List<string> Summaries = new List<string> {
             "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
         };
 
@@ -39,7 +39,7 @@ namespace WeatherService.Controllers
                     City = string.IsNullOrEmpty(city) ? "Default city" : city,
                     Date = DateTime.Now.AddDays(index),
                     TemperatureC = rng.Next(-20, 55),
-                    Summary = Summaries[rng.Next(Summaries.Length)]
+                    Summary = Summaries[rng.Next(Summaries.Count)]
                 })
                 .ToArray();
         }
@@ -60,9 +60,23 @@ namespace WeatherService.Controllers
                     City = string.IsNullOrEmpty(city) ? "Default city" : city,
                     Date = DateTime.Now.AddDays(index),
                     TemperatureC = rng.Next(-20, 55),
-                    Summary = Summaries[rng.Next(Summaries.Length)]
+                    Summary = Summaries[rng.Next(Summaries.Count)]
                 })
                 .ToArray();
+        }
+        
+        /// <summary>
+        /// Add new city to forecast
+        /// </summary>
+        /// <param name="city"></param>
+        /// <returns></returns>
+        [HttpPost]
+        [ApiVersion("2.0")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public OkResult PostV2([FromQuery] string city)
+        {
+            Summaries.Add(city);
+            return Ok();
         }
         
     }


### PR DESCRIPTION
This pull request is to fix a problem when using 2 or more routes with different upstream path but same downstream path (for example when having several authentication schemes for different groups of users).
The `AddAuth` method was trying to add 401-Unauthorized response several times to `OpenApiResponses` dictionary which results in an exception:

```
[17:00:34 ERR] An unhandled exception has occurred while executing the request. 
System.ArgumentException: An item with the same key has already been added. Key: 401
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at Swaggelot.SwaggerTransformer.AddAuth(ReRouteOptions route, OpenApiPathItem operations)
   at Swaggelot.SwaggerTransformer.ProcessWithInnerSwaggerForSingleDestinationDownstream(ReRouteOptions route, SwaggerDescriptor descriptor, OpenApiDocument innerDocument)
   at Swaggelot.SwaggerTransformer.ProcessWithInnerSwagger(ReRouteOptions route, SwaggerDescriptor descriptor, OpenApiDocument innerDocument)
   at Swaggelot.SwaggerTransformer.<>c__DisplayClass17_0.<ProcessReroute>b__3(KeyValuePair`2 tuple)
   at Swaggelot.Extensions.LinqExtensions.ForEach[T](IEnumerable`1 source, Action`1 action)
   at Swaggelot.SwaggerTransformer.ProcessReroute(ReRouteOptions route)
   at Swaggelot.SwaggerTransformer.Transform()
   at Swaggelot.Middlewares.SwaggelotMiddleware.InvokeAsync(HttpContext context, ISwaggerTransformer transformer, ILogger`1 logger)
   at Microsoft.AspNetCore.MiddlewareAnalysis.AnalysisMiddleware.Invoke(HttpContext httpContext)
   at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.MiddlewareAnalysis.AnalysisMiddleware.Invoke(HttpContext httpContext)
   at Microsoft.AspNetCore.Builder.Extensions.MapWhenMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.MiddlewareAnalysis.AnalysisMiddleware.Invoke(HttpContext httpContext)
   at Mb.Logging.Http.Middlewares.LoggingEndpointMiddleware.InvokeAsync(HttpContext context)
   at Microsoft.AspNetCore.MiddlewareAnalysis.AnalysisMiddleware.Invoke(HttpContext httpContext)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.MiddlewareAnalysis.AnalysisMiddleware.Invoke(HttpContext httpContext)
   at Hellang.Middleware.ProblemDetails.ProblemDetailsMiddleware.Invoke(HttpContext context)

```